### PR TITLE
Use pytest parametrize for testing

### DIFF
--- a/echopop/tests/test_standardize_coordinates.py
+++ b/echopop/tests/test_standardize_coordinates.py
@@ -2,8 +2,23 @@ import pandas as pd
 import numpy as np
 from echopop.survey import Survey
 from echopop.computation.spatial import transform_geometry
+import pytest
 
-def test_transform_geometry( ):
+
+@pytest.mark.parametrize(
+    "range_output, d_latlon",
+    [
+        # when `range_output == True` and no `d_longitude`/`d_latitude` input
+        (True, False),
+        # when `range_output == False` and no `d_longitude`/`d_latitude` input
+        (False, False),
+        # when `range_output == True` and with `d_longitude`/`d_latitude` input
+        (True, True),
+        # when `range_output == False` and with `d_longitude`/`d_latitude` input
+        (False, True),
+    ],
+)
+def test_transform_geometry(range_output, d_latlon):
 
     ### Mock data for `dataframe`
     test_dataframe = pd.DataFrame(
@@ -34,105 +49,112 @@ def test_transform_geometry( ):
     ### Mock data for `projection`
     test_projection = 'epsg:4326'
 
-    ### Evaluate when `range_output == True` and no `d_longitude`/`d_latitude` input
-    # ---- Expect: tuple output
-    output1 , output2 , output3 = transform_geometry( test_dataframe ,
-                                                      test_reference_grid ,
-                                                      test_kriging_grid_parameters ,
-                                                      test_projection ,
-                                                      range_output = True )
-    # ---- Check output type
-    assert isinstance( output1 , pd.DataFrame )
-    assert isinstance( output2 , float )
-    assert isinstance( output3 , float )
-    # ---- Check output shape
-    assert output1.shape == tuple( [ 5 , 10 ] )
-    # ---- Check data value equality
-    non_na_values = ~np.isnan( output1.longitude_transformed )
-    assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
-    assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
-    assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.205 , -0.706 , -0.206 ] ) ,
-                        rtol = 1e-1 )
-    assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.1 , -0.6 , -0.1 ] ) ,
-                        rtol = 1e-1 )
-    assert output2 == 85.0
-    assert output3 == 10.0
+    if not d_latlon:
+        if range_output:
+            ### Evaluate when `range_output == True` and no `d_longitude`/`d_latitude` input
+            # ---- Expect: tuple output
+            output1 , output2 , output3 = transform_geometry( test_dataframe ,
+                                                            test_reference_grid ,
+                                                            test_kriging_grid_parameters ,
+                                                            test_projection ,
+                                                            range_output = True )
+            # ---- Check output type
+            assert isinstance( output1 , pd.DataFrame )
+            assert isinstance( output2 , float )
+            assert isinstance( output3 , float )
+            # ---- Check output shape
+            assert output1.shape == tuple( [ 5 , 10 ] )
+            # ---- Check data value equality
+            non_na_values = ~np.isnan( output1.longitude_transformed )
+            assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
+            assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
+            assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.205 , -0.706 , -0.206 ] ) ,
+                                rtol = 1e-1 )
+            assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.1 , -0.6 , -0.1 ] ) ,
+                                rtol = 1e-1 )
+            assert output2 == 85.0
+            assert output3 == 10.0
 
-    ### Evaluate when `range_output == False` and no `d_longitude`/`d_latitude` input
-    # ---- Expect: single dataframe output
-    output1 = transform_geometry( test_dataframe ,
-                                  test_reference_grid ,
-                                  test_kriging_grid_parameters ,
-                                  test_projection ,
-                                  range_output = False )
-    # ---- Check output type
-    assert isinstance( output1 , pd.DataFrame )
-    # ---- Check output shape
-    assert output1.shape == tuple( [ 5 , 10 ] )
-    # ---- Check data value equality
-    non_na_values = ~np.isnan( output1.longitude_transformed )
-    assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
-    assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
-    assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.205 , -0.706 , -0.206 ] ) ,
-                        rtol = 1e-1 )
-    assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.1 , -0.6 , -0.1 ] ) ,
-                        rtol = 1e-1 )    
+        else:  # range_output=False
+            ### Evaluate when `range_output == False` and no `d_longitude`/`d_latitude` input
+            # ---- Expect: single dataframe output
+            output1 = transform_geometry( test_dataframe ,
+                                        test_reference_grid ,
+                                        test_kriging_grid_parameters ,
+                                        test_projection ,
+                                        range_output = False )
+            # ---- Check output type
+            assert isinstance( output1 , pd.DataFrame )
+            # ---- Check output shape
+            assert output1.shape == tuple( [ 5 , 10 ] )
+            # ---- Check data value equality
+            non_na_values = ~np.isnan( output1.longitude_transformed )
+            assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
+            assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
+            assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.205 , -0.706 , -0.206 ] ) ,
+                                rtol = 1e-1 )
+            assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.1 , -0.6 , -0.1 ] ) ,
+                                rtol = 1e-1 )    
     
-    ### Evaluate when `range_output == False` and `d_longitude`/`d_latitude` input
-    # ---- Expect: tuple
-    output1 = transform_geometry( test_dataframe ,
-                                  test_reference_grid ,
-                                  test_kriging_grid_parameters ,
-                                  test_projection ,
-                                  d_longitude = 60.0 ,
-                                  d_latitude = 5.0 ,
-                                  range_output = False )
-    # ---- Check output type
-    assert isinstance( output1 , pd.DataFrame )
-    # ---- Check output shape
-    assert output1.shape == tuple( [ 5 , 10 ] )
-    # ---- Check data value equality
-    non_na_values = ~np.isnan( output1.longitude_transformed )
-    assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
-    assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
-    assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.707 , -1.000 , -0.291 ] ) ,
-                        rtol = 1e-1 )
-    assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.558 , -0.850 , -0.142 ] ) ,
-                        rtol = 1e-1 )
+    else:  # d_latlon=True
+        if not range_output:
+            ### Evaluate when `range_output == False` and `d_longitude`/`d_latitude` input
+            # ---- Expect: tuple
+            output1 = transform_geometry( test_dataframe ,
+                                        test_reference_grid ,
+                                        test_kriging_grid_parameters ,
+                                        test_projection ,
+                                        d_longitude = 60.0 ,
+                                        d_latitude = 5.0 ,
+                                        range_output = False )
+            # ---- Check output type
+            assert isinstance( output1 , pd.DataFrame )
+            # ---- Check output shape
+            assert output1.shape == tuple( [ 5 , 10 ] )
+            # ---- Check data value equality
+            non_na_values = ~np.isnan( output1.longitude_transformed )
+            assert np.all( output1.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
+            assert np.isnan( output1.longitude_transformed[ 0 ] ) & np.isnan( output1.longitude_transformed[ 4 ] )
+            assert np.allclose( output1.x_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.707 , -1.000 , -0.291 ] ) ,
+                                rtol = 1e-1 )
+            assert np.allclose( output1.y_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.558 , -0.850 , -0.142 ] ) ,
+                                rtol = 1e-1 )
     
-    ### Evaluate when `range_output == True` and `d_longitude`/`d_latitude` input
-    # ---- Expect: single dataframe output
-    output11 , output22 , output33 = transform_geometry( test_dataframe ,
-                                                         test_reference_grid ,
-                                                         test_kriging_grid_parameters ,
-                                                         test_projection ,
-                                                         d_longitude = 60.0 ,
-                                                         d_latitude = 5.0 ,
-                                                         range_output = True )
-    # ---- Check output type
-    assert isinstance( output11 , pd.DataFrame )
-    assert isinstance( output22 , float )
-    assert isinstance( output33 , float )
-    # ---- Check output shape
-    assert output11.shape == tuple( [ 5 , 10 ] )
-    # ---- Check data value equality
-    non_na_values = ~np.isnan( output11.longitude_transformed )
-    assert np.all( output11.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
-    assert np.isnan( output11.longitude_transformed[ 0 ] ) & np.isnan( output11.longitude_transformed[ 4 ] )
-    assert np.allclose( output11.x_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.707 , -1.000 , -0.291 ] ) ,
-                        rtol = 1e-1 )
-    assert np.allclose( output11.y_transformed.values[ non_na_values ] , 
-                        np.array( [ -1.558 , -0.850 , -0.142 ] ) ,
-                        rtol = 1e-1 )
-    assert output22 == 60.0
-    assert output33 == 5.0
+        else:  # range_output=True
+            ### Evaluate when `range_output == True` and `d_longitude`/`d_latitude` input
+            # ---- Expect: single dataframe output
+            output11 , output22 , output33 = transform_geometry( test_dataframe ,
+                                                                test_reference_grid ,
+                                                                test_kriging_grid_parameters ,
+                                                                test_projection ,
+                                                                d_longitude = 60.0 ,
+                                                                d_latitude = 5.0 ,
+                                                                range_output = True )
+            # ---- Check output type
+            assert isinstance( output11 , pd.DataFrame )
+            assert isinstance( output22 , float )
+            assert isinstance( output33 , float )
+            # ---- Check output shape
+            assert output11.shape == tuple( [ 5 , 10 ] )
+            # ---- Check data value equality
+            non_na_values = ~np.isnan( output11.longitude_transformed )
+            assert np.all( output11.longitude_transformed[ non_na_values ] == np.array( [ -92.5 , -50.0 , -7.5 ] ) )
+            assert np.isnan( output11.longitude_transformed[ 0 ] ) & np.isnan( output11.longitude_transformed[ 4 ] )
+            assert np.allclose( output11.x_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.707 , -1.000 , -0.291 ] ) ,
+                                rtol = 1e-1 )
+            assert np.allclose( output11.y_transformed.values[ non_na_values ] , 
+                                np.array( [ -1.558 , -0.850 , -0.142 ] ) ,
+                                rtol = 1e-1 )
+            assert output22 == 60.0
+            assert output33 == 5.0
+
 
 def test_standardize_coordinates( mock_survey ):
 

--- a/echopop/tests/test_standardize_coordinates.py
+++ b/echopop/tests/test_standardize_coordinates.py
@@ -17,6 +17,12 @@ import pytest
         # when `range_output == False` and with `d_longitude`/`d_latitude` input
         (False, True),
     ],
+    ids=[
+        "range_True_latlon_False",
+        "range_False_latlon_False",
+        "range_True_latlon_True",
+        "range_False_latlon_True",
+    ]
 )
 def test_transform_geometry(range_output, d_latlon):
 


### PR DESCRIPTION
This is a case where pytest.parametrize could be useful, so I thought I'd make a PR and you could see a small example.
[@pytest.mark.parametrize: parametrizing test functions](https://docs.pytest.org/en/7.0.x/how-to/parametrize.html#pytest-mark-parametrize-parametrizing-test-functions)

It's nice because you could see/run each case individually with meaningful names:
<img width="289" alt="Screenshot 2024-04-14 at 12 43 53 PM" src="https://github.com/brandynlucca/echopop/assets/15334215/87ca7957-60ba-454b-98f7-a965133e4eee">
